### PR TITLE
Scrolling on the map

### DIFF
--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -17,7 +17,7 @@
   <script>
 
       var map = new ol.Map({
-        interactions : ol.interaction.defaults({doubleClickZoom :false, dragPan: false}),
+        interactions : ol.interaction.defaults({mouseWheelZoom: false, doubleClickZoom :false, dragPan: false}),
         layers: [
           new ol.layer.Tile({
             source: new ol.source.Stamen({


### PR DESCRIPTION
## What does this PR do?

Disable mousewheel zoom so you can scroll on the map
Scrolling was interrupted when the map appeared
### Related Issues

fixes #24
